### PR TITLE
Fix AUR PKGBUILD (dependencies, provides, etc)

### DIFF
--- a/packages/buildpkg/PKGBUILD
+++ b/packages/buildpkg/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Jason Scurtu <jscurtu@gmail.com>
+# Contributor: HurricanePootis <hurricanepootis@protonmail.com>
 pkgname=plasma6-applets-appgrid
-pkgver=1.1.0
+pkgver=1.2.1
 pkgrel=1
 pkgdesc="A modern fullscreen application launcher for KDE Plasma"
 arch=('x86_64')
@@ -9,32 +10,35 @@ license=('GPL-2.0-or-later')
 depends=(
     'plasma-workspace'
     'kservice'
-    'ki18n'
     'layer-shell-qt'
+    'qt6-base'
+    'kirigami'
+    'kiconthemes'
+    'ksvg'
+    'glibc'
+    'kio'
+    'milou'
+    'kdeclarative'
+    'qt6-declarative'
+    'libstdc++'
+    'libgcc'
+    'kcoreaddons'
+    'kwindowsystem'
+    'kcmutils'
+    'libplasma'
 )
 makedepends=(
     'cmake'
     'extra-cmake-modules'
-    'qt6-base'
-    'qt6-declarative'
-    'libplasma'
-    'kpackage'
-    'kio'
-    'kcoreaddons'
-    'kwindowsystem'
-    'gettext'
 )
-provides=('appgrid')
-conflicts=('appgrid')
-replaces=('appgrid')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/xarbit/plasma6-applet-appgrid/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('SKIP')
 
 build() {
     cmake -B build -S "plasma6-applet-appgrid-${pkgver}" \
-        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_BUILD_TYPE=None \
         -DCMAKE_INSTALL_PREFIX=/usr
-    cmake --build build -j$(nproc)
+    cmake --build build
 }
 
 package() {


### PR DESCRIPTION
Hi,

I am an AUR maintainer that maintains/co-maintains over 190+ packages on the AUR. I noticed some issues with your PKGBUILD. I left a comment on the package itself, but then I saw you keep a copy of the PKGBUILD in your repo. Therefore, this pull request does the following:

1. Properly assigns `depends()`. There is a tool called `namcap` which can determine what a package depends on. Using this in combination with `extra-x86_64-build` (which creates a clean chroot and automatically builds the package in it), I have determined the proper `depends()`.
2. Continuing that thread, I have removed any `makedepends()` that are now in `depends()`
3. The CMake build type was set to None as that is recommended by the CMake Package Guidelines.
4. I removed `-j$(nproc)`. If you want to keep that for your GitHub workflow build, that's fine. However, in actual systems, the number of work jobs is to be set by the user in `/etc/makepkg.conf`. Therefore, it is a bad idea to use nproc. 