### PR TITLE
fix: results auto-scroll repeatedly when hovering bottom-edge clipped

### DIFF
--- a/package/contents/ui/SearchResultsList.qml
+++ b/package/contents/ui/SearchResultsList.qml
@@ -40,31 +40,35 @@ ListView {
     property bool mouseMovedSinceReset: false
     onCountChanged: mouseMovedSinceReset = false
 
-    // Short window after a hover-triggered selection where new hover
-    // events are ignored. Prevents the cascade where revealing a clipped
-    // row scrolls the list under a stationary cursor, fires hover on the
-    // row that just slid into place, and chains. Issue #114.
-    property bool _hoverCooldown: false
+    // After revealing a clipped row, ignore hover entries caused by the list
+    // moving under a stationary cursor at the viewport edge.
+    property bool _hoverRevealSettling: false
     Timer {
-        id: hoverCooldownTimer
-        interval: 200
-        onTriggered: listView._hoverCooldown = false
+        id: hoverRevealSettlingTimer
+        interval: Math.max(Kirigami.Units.shortDuration, 120)
+        onTriggered: listView._hoverRevealSettling = false
     }
 
-    function _tryHoverSelect(row, localY, idx) {
+    function _tryHoverSelect(row, pointerY, idx) {
         if (!mouseMovedSinceReset) {
             mouseMovedSinceReset = true
             return
         }
-        if (_hoverCooldown)
+        if (_hoverRevealSettling)
             return
-        const rowY = row.mapToItem(listView, 0, 0).y
-        const clippedAtBottom = rowY + row.height > height
-        if (clippedAtBottom && localY > row.height - Kirigami.Units.gridUnit)
-            return
-        currentIndex = idx
-        _hoverCooldown = true
-        hoverCooldownTimer.restart()
+
+        const top = row.mapToItem(listView, 0, 0).y
+        const bottom = row.mapToItem(listView, 0, row.height).y
+        const clipped = top < 0 || bottom > height
+        const mouseYInList = row.mapToItem(listView, 0, pointerY).y
+        const inBottomEdge = mouseYInList > height - Kirigami.Units.smallSpacing * 2
+
+        if (!clipped || !inBottomEdge)
+            currentIndex = idx
+        if (clipped) {
+            _hoverRevealSettling = true
+            hoverRevealSettlingTimer.restart()
+        }
     }
 
     // PgDn lands on the partially-clipped bottom row so the user never


### PR DESCRIPTION
Fixes repeated auto-scroll in the search results list when hovering a partially clipped result at the bottom edge. (#114) 

Previously, hover selection blindly updated `currentIndex`. Because `ListView` reveals the current item, hovering a
clipped bottom result could scroll it into view. If the cursor stayed in the bottom-edge zone, the scroll could move the
next delegate under the stationary cursor, fire another hover-enter event, update `currentIndex` again, and repeat until
the list overshot the intended result.

This change makes the hover handler aware of that specific case:

- detects whether the hovered delegate is actually clipped
- detects whether the cursor is in the bottom-edge zone where scroll-induced hover re-entry occurs
- uses a short settling window after a clipped reveal to ignore follow-up hover-enter events caused by the list moving
under the cursor

Normal hover selection is preserved outside that narrow bottom-edge clipped-row case.

## Testing

- Built successfully with `cmake --build build`
- Ran `qmllint package/contents/ui/SearchResultsList.qml`
- Ran `QT_QPA_PLATFORM=offscreen ctest --test-dir /tmp/appgrid-review-build --output-on-failure`
- Manually verified that hovering clipped search results from multiple directions reveals the intended item once without repeated overscroll
