### PR TITLE
Fix search result arrow navigation after hover selection

### DIFF
--- a/package/contents/ui/js/searchresultnav.js
+++ b/package/contents/ui/js/searchresultnav.js
@@ -1,0 +1,33 @@
+/*
+    SPDX-FileCopyrightText: 2026 AppGrid Contributors
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+    Pure navigation helpers for search results while SearchBar owns focus.
+*/
+
+.pragma library
+
+function nextIndex(currentIndex, count, step, wrap) {
+    if (count <= 0)
+        return -1
+    if (count === 1)
+        return 0
+
+    const idx = Math.max(0, Math.min(count - 1, currentIndex))
+
+    if (step < 0) {
+        if (idx <= 0)
+            return wrap ? count - 1 : 0
+        return idx - 1
+    }
+
+    if (step > 0) {
+        if (idx <= 0)
+            return 1
+        if (idx >= count - 1)
+            return wrap ? 0 : count - 1
+        return idx + 1
+    }
+
+    return idx
+}

--- a/package/contents/ui/views/GridPanel.qml
+++ b/package/contents/ui/views/GridPanel.qml
@@ -15,6 +15,7 @@ import org.kde.plasma.components as PlasmaComponents
 import "../controllers"
 import "../widgets"
 import "../js/migrations.js" as Migrations
+import "../js/searchresultnav.js" as SearchResultNav
 
 Kirigami.ShadowedRectangle {
     id: panel
@@ -545,21 +546,15 @@ Kirigami.ShadowedRectangle {
                 }
                 readonly property int resultNavPrevious: -1
                 readonly property int resultNavNext: 1
-                function navigateToResults(step) {
+                function navigateToResults(step, wrap) {
                     if (panel.isSearching && !panel.isPrefixMode) {
-                        const count = searchResultsList.count
-                        if (count > 1) {
-                            const idx = searchResultsList.currentIndex
-                            if (step < 0) {
-                                if (idx <= 0)
-                                    return
-                                searchResultsList.currentIndex = idx - 1
-                            } else if (idx <= 0) {
-                                searchResultsList.currentIndex = 1
-                            } else if (step > 0) {
-                                searchResultsList.currentIndex = Math.min(count - 1, idx + 1)
-                            }
-                        }
+                        const next = SearchResultNav.nextIndex(
+                            searchResultsList.currentIndex,
+                            searchResultsList.count,
+                            step,
+                            wrap === true)
+                        if (next !== searchResultsList.currentIndex)
+                            searchResultsList.currentIndex = next
                     } else if (panel.showCategoryGrid) {
                         categoryGridView.forceActiveFocus()
                         if (categoryGridView.currentIndex < 0) {
@@ -602,7 +597,7 @@ Kirigami.ShadowedRectangle {
                         && !panel.isSearching)
                         panel._gridRevealed = false
                 }
-                onTabPressed: navigateToResults(resultNavNext)
+                onTabPressed: navigateToResults(resultNavNext, true)
                 onPageUp: if (panel.showSearchResults) searchResultsList.pageUp()
                 onPageDown: if (panel.showSearchResults) searchResultsList.pageDown()
                 onHome: if (panel.showSearchResults) searchResultsList.goHome()

--- a/package/contents/ui/views/GridPanel.qml
+++ b/package/contents/ui/views/GridPanel.qml
@@ -543,16 +543,22 @@ Kirigami.ShadowedRectangle {
                         }
                     }
                 }
-                function navigateToResults() {
+                readonly property int resultNavPrevious: -1
+                readonly property int resultNavNext: 1
+                function navigateToResults(step) {
                     if (panel.isSearching && !panel.isPrefixMode) {
-                        if (searchResultsList.count > 1) {
-                            searchResultsList.forceActiveFocus()
-                            // Respect a hover-set position; otherwise skip the
-                            // default top row so Down advances visibly.
-                            if (searchResultsList.currentIndex <= 0)
+                        const count = searchResultsList.count
+                        if (count > 1) {
+                            const idx = searchResultsList.currentIndex
+                            if (step < 0) {
+                                if (idx <= 0)
+                                    return
+                                searchResultsList.currentIndex = idx - 1
+                            } else if (idx <= 0) {
                                 searchResultsList.currentIndex = 1
-                        } else if (searchResultsList.count === 1) {
-                            searchResultsList.forceActiveFocus()
+                            } else if (step > 0) {
+                                searchResultsList.currentIndex = Math.min(count - 1, idx + 1)
+                            }
                         }
                     } else if (panel.showCategoryGrid) {
                         categoryGridView.forceActiveFocus()
@@ -585,14 +591,18 @@ Kirigami.ShadowedRectangle {
                         panel._gridRevealed = true
                         return
                     }
-                    navigateToResults()
+                    navigateToResults(resultNavNext)
                 }
                 onMoveUp: {
+                    if (panel.isSearching && !panel.isPrefixMode) {
+                        navigateToResults(resultNavPrevious)
+                        return
+                    }
                     if (panel.cfgHideGridWhenEmpty && panel._gridRevealed
                         && !panel.isSearching)
                         panel._gridRevealed = false
                 }
-                onTabPressed: navigateToResults()
+                onTabPressed: navigateToResults(resultNavNext)
                 onPageUp: if (panel.showSearchResults) searchResultsList.pageUp()
                 onPageDown: if (panel.showSearchResults) searchResultsList.pageDown()
                 onHome: if (panel.showSearchResults) searchResultsList.goHome()

--- a/package/contents/ui/views/SearchResultsList.qml
+++ b/package/contents/ui/views/SearchResultsList.qml
@@ -32,7 +32,6 @@ ListView {
     reuseItems: true
 
     currentIndex: count > 0 ? 0 : -1
-    keyNavigationEnabled: true
 
     property bool animateHighlight: true
     // Keyboard nav animates the highlight; hover-driven selects snap so the
@@ -200,67 +199,6 @@ ListView {
               ? i18nd("dev.xarbit.appgrid", "No results for \"%1\"", searchField.text)
               : ""
         visible: listView.count === 0 && searchField && searchField.text.length > 0
-    }
-
-    Keys.onReturnPressed: if (currentIndex >= 0) listView.launched(currentIndex)
-    Keys.onEnterPressed: if (currentIndex >= 0) listView.launched(currentIndex)
-
-    Keys.onPressed: function(event) {
-        if (event.modifiers & Qt.AltModifier) {
-            const num = event.key - Qt.Key_0
-            if (num >= 1 && num <= 9 && num <= count) {
-                launched(num - 1)
-                event.accepted = true
-                return
-            }
-        }
-
-        switch (event.key) {
-        case Qt.Key_PageDown: pageDown(); event.accepted = true; return
-        case Qt.Key_PageUp:   pageUp();   event.accepted = true; return
-        case Qt.Key_Home:     goHome();   event.accepted = true; return
-        case Qt.Key_End:      goEnd();    event.accepted = true; return
-        }
-
-        if (event.key === Qt.Key_Backspace || event.key === Qt.Key_Delete) {
-            searchField.forceActiveFocus()
-            searchField.text = searchField.text.slice(0, -1)
-            event.accepted = true
-        } else if (event.text.length > 0 && !event.modifiers) {
-            searchField.forceActiveFocus()
-            searchField.text += event.text
-            event.accepted = true
-        }
-    }
-
-    Keys.onDownPressed: {
-        if (currentIndex < count - 1)
-            currentIndex++
-    }
-
-    Keys.onUpPressed: {
-        if (currentIndex > 0)
-            currentIndex--
-        else if (searchField)
-            searchField.forceActiveFocus()
-    }
-
-    Keys.onTabPressed: {
-        if (currentIndex < count - 1)
-            currentIndex++
-        else
-            currentIndex = 0
-    }
-
-    Keys.onBacktabPressed: {
-        if (currentIndex > 0)
-            currentIndex--
-        else
-            currentIndex = count - 1
-    }
-
-    Keys.onEscapePressed: {
-        if (searchField) searchField.forceActiveFocus()
     }
 
     delegate: PlasmaComponents.ItemDelegate {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,11 @@ if(Qt6QuickTest_FOUND)
         ${CMAKE_CURRENT_SOURCE_DIR}/qml/headeractions.js
         COPYONLY
     )
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/package/contents/ui/js/searchresultnav.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/qml/searchresultnav.js
+        COPYONLY
+    )
 
     add_executable(tst_qml qml/main.cpp)
     target_link_libraries(tst_qml PRIVATE Qt6::QuickTest Qt6::Quick Qt6::Qml Qt6::Core)

--- a/tests/qml/searchresultnav.js
+++ b/tests/qml/searchresultnav.js
@@ -1,0 +1,33 @@
+/*
+    SPDX-FileCopyrightText: 2026 AppGrid Contributors
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+    Pure navigation helpers for search results while SearchBar owns focus.
+*/
+
+.pragma library
+
+function nextIndex(currentIndex, count, step, wrap) {
+    if (count <= 0)
+        return -1
+    if (count === 1)
+        return 0
+
+    const idx = Math.max(0, Math.min(count - 1, currentIndex))
+
+    if (step < 0) {
+        if (idx <= 0)
+            return wrap ? count - 1 : 0
+        return idx - 1
+    }
+
+    if (step > 0) {
+        if (idx <= 0)
+            return 1
+        if (idx >= count - 1)
+            return wrap ? 0 : count - 1
+        return idx + 1
+    }
+
+    return idx
+}

--- a/tests/qml/tst_SearchResultNav.qml
+++ b/tests/qml/tst_SearchResultNav.qml
@@ -1,0 +1,36 @@
+/*
+    SPDX-FileCopyrightText: 2026 AppGrid Contributors
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+    Coverage for search-result navigation while SearchBar owns focus.
+*/
+
+import QtQuick
+import QtTest
+import "searchresultnav.js" as SearchResultNav
+
+TestCase {
+    name: "SearchResultNav"
+
+    function test_upAtTopStaysOnTop() {
+        compare(SearchResultNav.nextIndex(0, 5, -1, false), 0)
+    }
+
+    function test_downSkipsTopRow() {
+        compare(SearchResultNav.nextIndex(0, 5, 1, false), 1)
+    }
+
+    function test_downClampsAtBottom() {
+        compare(SearchResultNav.nextIndex(4, 5, 1, false), 4)
+    }
+
+    function test_tabWrapsAtBottom() {
+        compare(SearchResultNav.nextIndex(4, 5, 1, true), 0)
+    }
+
+    function test_singleResultStaysSelected() {
+        compare(SearchResultNav.nextIndex(0, 1, 1, false), 0)
+        compare(SearchResultNav.nextIndex(0, 1, -1, false), 0)
+        compare(SearchResultNav.nextIndex(0, 1, 1, true), 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fix keyboard navigation in search results after the mouse hover has moved the current selection.  (#148)

Previously, when search results were visible and the pointer moved over a result, hover selection updated `searchResultsList.currentIndex`, but the next arrow key from the search field did not consistently move from that hovered row:

  - Up could be ignored when first pressed.
  - Down could require a second press before movement was visible.

This changes `navigateToResults()` to accept a direction and update `searchResultsList.currentIndex` directly from the search field, using the current hover-selected index as the starting point.

The search field keeps focus during search-result arrow navigation, avoiding focus handoff side effects between the text field and result list.

## Behavior

  - Down from the search field advances from the current result.
  - Up from the search field moves upward from the current result.
  - Up at the first result remains a no-op.
  - Tab keeps using forward navigation.
  - Non-search navigation paths are unchanged.s