### PR TITLE
Backport: fix search arrow nav after hover (#148)

### DIFF
--- a/package/contents/ui/GridPanel.qml
+++ b/package/contents/ui/GridPanel.qml
@@ -595,16 +595,22 @@ Kirigami.ShadowedRectangle {
                         }
                     }
                 }
-                function navigateToResults() {
+                readonly property int resultNavPrevious: -1
+                readonly property int resultNavNext: 1
+                function navigateToResults(step) {
                     if (panel.isSearching && !panel.isPrefixMode) {
-                        if (searchResultsList.count > 1) {
-                            searchResultsList.forceActiveFocus()
-                            // Respect a hover-set position; otherwise skip the
-                            // default top row so Down advances visibly.
-                            if (searchResultsList.currentIndex <= 0)
+                        const count = searchResultsList.count
+                        if (count > 1) {
+                            const idx = searchResultsList.currentIndex
+                            if (step < 0) {
+                                if (idx <= 0)
+                                    return
+                                searchResultsList.currentIndex = idx - 1
+                            } else if (idx <= 0) {
                                 searchResultsList.currentIndex = 1
-                        } else if (searchResultsList.count === 1) {
-                            searchResultsList.forceActiveFocus()
+                            } else if (step > 0) {
+                                searchResultsList.currentIndex = Math.min(count - 1, idx + 1)
+                            }
                         }
                     } else if (panel.showCategoryGrid) {
                         categoryGridView.forceActiveFocus()
@@ -630,9 +636,13 @@ Kirigami.ShadowedRectangle {
                         prefixModeView.focusFileList()
                         return
                     }
-                    navigateToResults()
+                    navigateToResults(resultNavNext)
                 }
-                onTabPressed: navigateToResults()
+                onMoveUp: {
+                    if (panel.isSearching && !panel.isPrefixMode)
+                        navigateToResults(resultNavPrevious)
+                }
+                onTabPressed: navigateToResults(resultNavNext)
                 onPageUp: if (panel.showSearchResults) searchResultsList.pageUp()
                 onPageDown: if (panel.showSearchResults) searchResultsList.pageDown()
                 onHome: if (panel.showSearchResults) searchResultsList.goHome()

--- a/package/contents/ui/SearchBar.qml
+++ b/package/contents/ui/SearchBar.qml
@@ -18,6 +18,7 @@ RowLayout {
 
     signal accepted()
     signal moveDown()
+    signal moveUp()
     signal tabPressed()
     signal pageUp()
     signal pageDown()
@@ -51,6 +52,7 @@ RowLayout {
         Keys.onReturnPressed: searchBar.accepted()
         Keys.onEnterPressed: searchBar.accepted()
         Keys.onDownPressed: searchBar.moveDown()
+        Keys.onUpPressed: searchBar.moveUp()
         Keys.onTabPressed: searchBar.tabPressed()
         Keys.onPressed: function(event) {
             switch (event.key) {


### PR DESCRIPTION
Backport of #149 to 1.8.x. Credits @Caelestis94. Adds the SearchBar moveUp signal
  (main-only prerequisite).