### PR TITLE
docs: remove flake mention in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Built, signed, and published by the AppGrid maintainer. These are the channels s
 | **Ubuntu 25.10+** (Launchpad PPA) | `sudo add-apt-repository ppa:xarbit/plasma-applet-appgrid && sudo apt install plasma-applet-appgrid` |
 | **Fedora** (Copr) | `sudo dnf copr enable scujas/plasma-applet-appgrid && sudo dnf install plasma-applet-appgrid` |
 | **Immutable distros** (KDE Linux, Kinoite, Bazzite, Aurora, Kalpa, SteamOS) | Universal `~/.local/` tarball — see [INSTALL.TXT](packaging/universal/INSTALL.TXT) |
-| **Nix / NixOS** | Flake — see [packaging/nix/README.md](packaging/nix/README.md) |
+| **Nix / NixOS** | See [packaging/nix/README.md](packaging/nix/README.md) |
 
 After install: right-click the panel launcher → **Show Alternatives** → **AppGrid**.
 


### PR DESCRIPTION
since the build for it was dropped in https://github.com/xarbit/plasma6-applet-appgrid/commit/b557e7b7d42905e6f0c578554a2a93403f7a5277

will also need to update https://github.com/xarbit/plasma6-applet-appgrid/blob/main/packaging/nix/README.md